### PR TITLE
Update objective-c starter app to receive badge notifications

### DIFF
--- a/ObjCQuickstart/AppDelegate.m
+++ b/ObjCQuickstart/AppDelegate.m
@@ -25,9 +25,11 @@
     }];
   } else if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
     [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings
-                                                                         settingsForTypes:(UIUserNotificationTypeAlert)
+                                                                         settingsForTypes:(UIUserNotificationTypeSound |
+                                                                          UIUserNotificationTypeAlert |
+                                                                          UIUserNotificationTypeBadge)
                                                                          categories:nil]];
-    
+
     [[UIApplication sharedApplication] registerForRemoteNotifications];
   } else {
     [[UIApplication sharedApplication] registerForRemoteNotifications];


### PR DESCRIPTION
Update objective-c code as required by [DEVED-2345](https://issues.corp.twilio.com/browse/DEVED-2345) to enable badge notifications.